### PR TITLE
feat: add Chiliz and Chiliz Spicy (testnet) network support

### DIFF
--- a/src/networks.ts
+++ b/src/networks.ts
@@ -804,6 +804,22 @@ export const _networkInfo: Array<NetworkInfo> = [
     baseAPI: "https://transaction-alpen-testnet.safe.protofire.io/api/v1",
     stagingBaseAPI: "https://transaction-alpen-testnet.stage.safe.protofire.io/api/v1",
   },
+  {
+    chainID: 88888,
+    name: "Chiliz",
+    shortName: "chzmainnet",
+    currencySymbol: "CHZ",
+    baseAPI: "https://transaction.safe.chiliz.com/api/v1",
+    stagingBaseAPI: "https://transaction.staging.safe.chiliz.com/api/v1",
+  },
+  {
+    chainID: 88882,
+    name: "Chiliz Spicy",
+    shortName: "chzspicy",
+    currencySymbol: "CHZ",
+    baseAPI: "https://transaction-testnet.safe.chiliz.com/api/v1",
+    stagingBaseAPI: "https://transaction-testnet.staging.safe.chiliz.com/api/v1",
+  },
 ];
 
 export const networkInfo = new Map<number, NetworkInfo>(_networkInfo.map((info) => [info.chainID, info]));


### PR DESCRIPTION
## Summary
- Add Chiliz mainnet (chainID: 88888) to supported networks
- Add Chiliz Spicy testnet (chainID: 88882) to supported networks
- Both networks use CHZ as native currency

## Test plan
- [x] Build passes
- [x] All 136 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)